### PR TITLE
Fix for paths containing spaces

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -436,7 +436,7 @@ try {
         if (-not (Test-Path -Path:$msi -PathType:leaf)) {
             Write-Error "$msi does not exist." -ErrorAction:Stop
         }
-        @('/i', $msi)
+        @('/i', """$msi""")
     } else {
         if ($null -eq $uninstallGUID) {
             Write-Error "'$displayName' already uninstalled." -ErrorAction:Stop


### PR DESCRIPTION
The $msi needs to be encapsulated with double quotes otherwise the script fails for paths containing spaces