### PR TITLE
Update Install.ps1

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -567,7 +567,7 @@ function Test-ExternalScripts {
         }       
         ## validate it is an "onboarding" script.
         $on = Get-Content -LiteralPath:$OnboardingScript | Where-Object {
-            $_ -match 'reg\s+add\s+"HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Advanced Threat Protection"\s+\/v\s+OnboardingInfo'
+            $_ -match 'add\s+"HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Advanced Threat Protection"\s+\/v\s+OnboardingInfo'
         }
         if ($on.Length -eq 0) {
             Exit-Install -Message:"Not an onboarding script: $OnboardingScript" -ExitCode:$ERR_INVALID_PARAMETER
@@ -590,7 +590,7 @@ function Test-ExternalScripts {
         }
 
         $off = Get-Content -LiteralPath:$OffboardingScript | Where-Object {
-            $_ -match 'reg\s+add\s+"HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Advanced Threat Protection"\s+\/v\s+696C1FA1-4030-4FA4-8713-FAF9B2EA7C0A'
+            $_ -match 'add\s+"HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Advanced Threat Protection"\s+\/v\s+696C1FA1-4030-4FA4-8713-FAF9B2EA7C0A'
         }
         
         if ($off.Length -eq 0) {

--- a/Install.ps1
+++ b/Install.ps1
@@ -284,9 +284,9 @@ function Get-ScriptVersion {
     ## DO NOT EDIT THIS BLOCK - BEGIN
     $version = @{
         Major    = '1'
-        Minor    = '20230922'
+        Minor    = '20231204'
         Patch    = '0'
-        Metadata = 'A08BC943'
+        Metadata = 'E8E12DEA'
     }
     ## DO NOT EDIT THIS BLOCK - END
     [bool] $seen = $false


### PR DESCRIPTION
Adjusting the match so it starts with "add" instead of "reg". The underlying onboarding or offboarding script can sometimes refer to reg.exe and so the install.ps1 will incorrectly fail to find a match.